### PR TITLE
added max width to results container

### DIFF
--- a/source/result-matching.html
+++ b/source/result-matching.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div id="page-info">
-    <img src="../assets/backarrow-blue.svg" alt="back arrow"/>
+    <img src="../../assets/backarrow-blue.svg" alt="back arrow"/>
   </div>
   <main id="content" aria-label="Score summary">
     <div id="result-card">

--- a/source/result-sequence.html
+++ b/source/result-sequence.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div id="page-info">
-    <img src="../assets/backarrow-blue.svg" alt="back arrow"/>
+    <img src="../../assets/backarrow-blue.svg" alt="back arrow"/>
   </div>
   <main id="content" aria-label="Score summary">
     <div id="result-card">

--- a/source/styles/result-matching.css
+++ b/source/styles/result-matching.css
@@ -129,6 +129,12 @@
     align-items: center;
     padding: 0.5rem 1rem;
   }
+
+ @media (width <= 480px) {
+    #result-card {
+      max-width: 85%;
+    }
+ }
   
   .theme-toggle {
     width: 70px;

--- a/source/styles/result-matching.css
+++ b/source/styles/result-matching.css
@@ -261,12 +261,12 @@
   }
 
   body.dark #page-info img {
-    content: url('../assets/backarrow-white.svg');
+    content: url('../../assets/backarrow-white.svg');
   }
   
   body.dark #result-card{ 
     background-color: #174517;
-    background-image: url("../assets/blur-bg-darkmode.svg");
+    background-image: url("../../assets/blur-bg-darkmode.svg");
     color:#fff
   }
 

--- a/source/styles/result-sequence.css
+++ b/source/styles/result-sequence.css
@@ -116,6 +116,12 @@ footer {
   padding: 0.5rem 1rem;
 }
 
+@media (width <= 480px) {
+    #result-card {
+      max-width: 85%;
+    }
+ }
+ 
 .theme-toggle {
   width: 70px;
   height: 34px;


### PR DESCRIPTION
Added max width to results container on smaller screens so it displays more nicely
<img width="532" alt="Screenshot 2025-06-07 at 6 04 38 PM" src="https://github.com/user-attachments/assets/b8721973-e1d1-4e05-8749-17bbcce47da3" />
