### PR TITLE
Fix back arrow bug

### DIFF
--- a/source/result-matching.html
+++ b/source/result-matching.html
@@ -15,7 +15,7 @@
     <strong>Warning:</strong> This site relies on JavaScript for interactive features. Please enable it to get the full experience.
   </noscript>
   <div id="page-info">
-    <img src="../../assets/backarrow-blue.svg" alt="back arrow"/>
+    <img src="../assets/backarrow-blue.svg" alt="back arrow"/>
   </div>
   <main id="content" aria-label="Score summary">
     <div id="result-card">

--- a/source/result-sequence.html
+++ b/source/result-sequence.html
@@ -15,7 +15,7 @@
     <strong>Warning:</strong> This site relies on JavaScript for interactive features. Please enable it to get the full experience.
   </noscript>
   <div id="page-info">
-    <img src="../../assets/backarrow-blue.svg" alt="back arrow"/>
+    <img src="../assets/backarrow-blue.svg" alt="back arrow"/>
   </div>
   <main id="content" aria-label="Score summary">
     <div id="result-card">


### PR DESCRIPTION
back arrow should show up properly in results-sequence and results-matching